### PR TITLE
Chomp slurp() input

### DIFF
--- a/lib/Mojolicious/Command/nopaste/Service.pm
+++ b/lib/Mojolicious/Command/nopaste/Service.pm
@@ -93,9 +93,16 @@ sub paste { die 'Not implemented' }
 sub slurp { 
   my ($self, @files) = @_;
   @files = @{ $self->files } unless @files;
-  local $/; 
-  local @ARGV = @files;
-  return decode 'UTF-8', <>;
+
+  my $content = do {
+    local $/;
+    local @ARGV = @files;
+    decode 'UTF-8', <>;
+  };
+
+  # Remove trailing newline as some sites won't do it for us
+  chomp $content;
+  return $content;
 }
 
 sub post_to_irc {


### PR DESCRIPTION
Some sites don't do this for us (shadowcat, fpaste) and show one
extra, empty line at the end of every pasted file.

Without this change, a file which might look like:

1. use Mojolicious;
2. say 'mojo!';

Will be pasted as:

1. use Mojolicious;
2. say 'mojo!';
3. 

---

This change doesn't appear to break any existing services. I've moved the slurp code into a `do` block, mostly so that `$/` still has its default value for my use of `chomp()`.