### PR TITLE
require IO::Socket::SSL 1.94 for https

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -13,6 +13,7 @@ my $build = Module::Build->new(
   requires => {
     'Mojolicious' => '4.0',
     'File::HomeDir' => 0,
+    'IO::Socket::SSL' => '1.94',
   },
   meta_merge => {
     resources => {


### PR DESCRIPTION
Mojolicious requires IO::Socket::SSL 1.94 or higher to enable SSL
sockets for handling HTTPS. Since we use HTTPS explicitly for Github
(the gist service), we need to depend on it explicitly.

---

If the user is missing IO::Socket::SSL, the connection to gist dies with a warning about undefined values in `say`. Using `MOJO_USERAGENT_DEBUG=1` shined no light on the problem at all. I had to go in and start dumping random objects to find out there was an error in the Mojo::Transaction object, and then I could find the real problem.

An alternative would be to bail out earlier if they're missing IO::Socket::SSL, or bail out with a better error message (check the `Mojo::Transaction->error` field).
